### PR TITLE
Ensure {arch} for linux binary

### DIFF
--- a/terraform.toml
+++ b/terraform.toml
@@ -5,7 +5,7 @@ name = "terraform"
 type = "cli"
 
 [platform.linux]
-download-file = "terraform_{version}_linux_amd64.zip"
+download-file = "terraform_{version}_linux_{arch}.zip"
 bin-path = "terraform"
 checksum-file = "terraform_{version}_SHA256SUMS"
 


### PR DESCRIPTION
Linux download path hardcoded amd64, this will allow this to build properly on arm.